### PR TITLE
Fix typo in Windows configuration path in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -247,7 +247,7 @@ Else, a file with the name `animdl_config.yml` in the working directory will be 
 
 Futhermore, the configuration files can be globally placed at:
 - Windows:
-    - `%USERPROILE%/.animdl/config.yml`
+    - `%USERPROFILE%/.animdl/config.yml`
 - Anything else:
     - `$HOME/.config/animdl/config.yml`
 


### PR DESCRIPTION
`%USERPROILE%/.animdl/config.yml` should read `%USERPROFILE%/.animdl/config.yml` (missing an `F`)

Definitely didn't copy + paste it multiple times before realizing...

*Also ty for the great program!*