### PR TITLE
Fix rpc episode selection.

### DIFF
--- a/animdl/core/cli/helpers/rpc.py
+++ b/animdl/core/cli/helpers/rpc.py
@@ -76,7 +76,7 @@ def set_streaming_episode(session, anime_name, episode):
 
     around = episode - (episode % 10)
 
-    current = get_episodes(session, anime["id"], around)[episode % 11 - 1]
+    current = get_episodes(session, anime["id"], around)[episode % 10 - 1]
 
     episode_thumbnail = (current.get("attributes", {}).get("thumbnail", {}) or {}).get(
         "original", "mascot"


### PR DESCRIPTION
Correct me if I'm wrong, but this should select the correct episode for discord rpc and solve any index of range errors.

I originally encountered this problem when running, e.g.:
```
animdl stream gogoanime:Nana -r 43 --auto --index 1
```
which gives the error:
```
  ...
  File "/usr/lib/python3.10/site-packages/animdl/core/cli/commands/stream.py", line 229, in animdl_stream
    set_streaming_episode(session, content_title, episode_number)
  File "/usr/lib/python3.10/site-packages/animdl/core/cli/helpers/rpc.py", line 79, in set_streaming_episode
    current = get_episodes(session, anime["id"], around)[episode % 11 - 1]
IndexError: list index out of range
```