### PR TITLE
Fix windows path separator in the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -240,7 +240,7 @@ Else, a file with the name `animdl_config.yml` in the working directory will be 
 Futhermore, the configuration files can be globally placed at:
 
 - Windows:
-  - `%USERPROFILE%/.animdl/config.yml`
+  - `%USERPROFILE%\.animdl\config.yml`
 - Anything else:
   - `$HOME/.config/animdl/config.yml`
 


### PR DESCRIPTION
Hi! Just noticed a small error in the readme, hope it helps!

`%USERPROFILE%/.animdl/config.yml` -> `%USERPROFILE%\.animdl\config.yml`