### PR TITLE
mpv: fix WebVTT subtitles

### DIFF
--- a/animdl/core/cli/helpers/players/mpv.py
+++ b/animdl/core/cli/helpers/players/mpv.py
@@ -51,12 +51,14 @@ class MPVDefaultPlayer(BasePlayer):
             )
 
         if subtitles is not None:
+            subtitles_result = map(
+                lambda subtitle: subtitle.replace("https:", "https\:"), subtitles
+            )
             args += (
-                f"{self.opts_spec['subtitles']}={self.path_joiner.join(subtitles)}",
+                f"{self.opts_spec['subtitles']}={self.path_joiner.join(subtitles_result)}",
             )
 
         if chapters:
-
             # NOTE: This could be achieved with a PIPE.
             # This is not done in this case because you
             # only PIPE one argument at a time, and this


### PR DESCRIPTION
The subtitles are passed separated by ':' as a result it will consider
https and // to be different files and therefore failing to load.