### PR TITLE
Removes extra https: when iframe src url already includes it

### DIFF
--- a/animdl/core/codebase/providers/gogoanime/__init__.py
+++ b/animdl/core/codebase/providers/gogoanime/__init__.py
@@ -51,7 +51,10 @@ def get_quality(url_text):
 
 def get_embed_page(session, episode_url):
     content_parsed = htmlparser.fromstring(session.get(episode_url).text)
-    return "https:{}".format(content_parsed.cssselect("iframe")[0].get("src"))
+    iframe_src_url = content_parsed.cssselect("iframe")[0].get("src")
+    if iframe_src_url.startswith("https:"):
+        return iframe_src_url
+    return "https:{}".format(iframe_src_url)
 
 
 def fetcher(session, url, check, match):


### PR DESCRIPTION
## Overview
I recently encountered a bug that breaks the `animdl grab` and `animdl download` scripts for the `gogoanime` provider.

To reproduce this bug, run `animdl grab "Megami no cafe"` or `animdl download "Megami no cafe"`.

The following is a screenshot of the output of `animdl grab "Megami no cafe"`:

<img width="1233" alt="image" src="https://github.com/justfoolingaround/animdl/assets/5039913/3b9255b7-79a2-455b-b4e3-ff0369a3a596">

I pulled the repo, and in debugging the issue, I noticed that the `get_embed_page` function in the `gogoanime` provider is breaking the URL by adding an additional `https:` to the front of the URL it is grabbing from the iframe on the page.

## Testing

Prior to the changes from this pull request, the `get_embed_page` function was returning a URL that looked like this:
```
https:https://gotaku1.com/streaming.php?id=MjAyMzgw&title=Megami+no+Caf%C3%A9+Terrace+Episode+1
```

After making the changes in this pull request, the `get_embed_page` function now returns the URL as follows:

```
https://gotaku1.com/streaming.php?id=MjAyMzgw&title=Megami+no+Caf%C3%A9+Terrace+Episode+1
```

After making the change, I tested the `download` and `grab` functions, and they work now.

## Considerations
I noticed this bug recently (within the last two weeks). My assumption is that the there was a recent change to the format of the page that is being parsed. Presumably, before the bug started occurring, the URL parsed from the iframe was missing the `https:` from the front, but the `https:` is included.

I updated the code to conditionally add an `https:` to the front of the URL in case this was not a widespread change. I want to make sure this works with the old format and the new format in case there are still some pages that are missing the `https:` from the front of the URL.

Let me know if you have any concerns about this approach.