### PR TITLE
chore: Improve version management in packaging build process

### DIFF
--- a/animdl/core/__version__.py
+++ b/animdl/core/__version__.py
@@ -1,1 +1,3 @@
-__core__ = "1.7.14"
+import importlib.metadata
+
+__core__ = importlib.metadata.version("animdl")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "animdl"
-version = "1.7.12"
+version = "1.7.15"
 description = "A highly efficient, fast, powerful and light-weight anime downloader and streamer for your favorite anime."
 readme = "readme.txt"
 authors = [ "justfoolingaround <kr.justfoolingaround@gmail.com>",]


### PR DESCRIPTION
This will fix issue #272

Version in pyproject.toml was not bumped last two patches.
Firstly, this will bump the version to 1.7.15.
Secondly, for easier maintaining in the future. I would suggest using a variable from importlib.metadata in animdl/core/__version__.py.
In this way, the version has only to be maintained in pyproject.toml.

[Source](https://stackoverflow.com/a/67097076/5516320)