### PR TITLE
fix: fetch version from pyproject.toml

### DIFF
--- a/animdl/__main__.py
+++ b/animdl/__main__.py
@@ -70,12 +70,12 @@ def __animdl_cli__(ctx: click.Context, disable_update):
 
             from .core.cli.http_client import client
 
-            branch, version_file = constants.VERSION_FILE_PATH
+            branch, pyproject_file = constants.PYPROJECT_FILE_PATH
 
             upstream_version = regexlib.search(
-                r'__core__ = "(.*?)"',
+                r'version = "(.*?)"',
                 client.get(
-                    f"https://raw.githubusercontent.com/{author}/{repository_name}/{branch}/{version_file}"
+                    f"https://raw.githubusercontent.com/{author}/{repository_name}/{branch}/{pyproject_file}"
                 ).text,
             ).group(1)
 

--- a/animdl/core/cli/helpers/banner.py
+++ b/animdl/core/cli/helpers/banner.py
@@ -4,20 +4,20 @@ import click
 import regex
 from anchor.strings import iter_contentaware_segments
 
-from .constants import SOURCE_REPOSITORY, VERSION_FILE_PATH
+from .constants import SOURCE_REPOSITORY, PYPROJECT_FILE_PATH
 from .stream_handlers import get_console
 
-VERSION_REGEX = regex.compile(r'__core__ = "(.*?)"')
+VERSION_REGEX = regex.compile(r'version = "(.*?)"')
 
 
 def fetch_upstream_version(session):
 
     author, repository_name = SOURCE_REPOSITORY
-    branch, version_file = VERSION_FILE_PATH
+    branch, pyproject_file = PYPROJECT_FILE_PATH
 
     upstream_version = VERSION_REGEX.search(
         session.get(
-            f"https://raw.githubusercontent.com/{author}/{repository_name}/{branch}/{version_file}"
+            f"https://raw.githubusercontent.com/{author}/{repository_name}/{branch}/{pyproject_file}"
         ).text
     ).group(1)
 

--- a/animdl/core/cli/helpers/constants.py
+++ b/animdl/core/cli/helpers/constants.py
@@ -7,3 +7,4 @@ LABELS = {
 SOURCE_REPOSITORY = "justfoolingaround", "animdl"
 MODULE_NAME = "animdl"
 VERSION_FILE_PATH = "master", "animdl/core/__version__.py"
+PYPROJECT_FILE_PATH = "master", "pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "animdl"
-version = "1.7.15"
+version = "1.7.16"
 description = "A highly efficient, fast, powerful and light-weight anime downloader and streamer for your favorite anime."
 readme = "readme.txt"
 authors = [ "justfoolingaround <kr.justfoolingaround@gmail.com>",]


### PR DESCRIPTION
Fix for #274 caused by #273 

### Problem
Version management was improved by last merged pr. The version checker parses the version file animdl/core/__version__.py online and still expects the hardcoded value.


### Solution
This pr redirects the target for the regex to pyproject.toml, to support the version management improvement.

I have added a new constant, to clearly distinguish it from the version file.
But I kept the constant VERSION_FILE_PATH. It is not referenced anywhere else in the code anymore, but maybe it is useful in the future(?).
