### PR TITLE
Fix: 9anime + Vidstream extractor

### DIFF
--- a/animdl/core/codebase/extractors/vidstream/__init__.py
+++ b/animdl/core/codebase/extractors/vidstream/__init__.py
@@ -12,22 +12,22 @@ EMBED_URL_REGEX = regex.compile(r"(.+?)/(?:e(?:mbed)?)/([a-zA-Z0-9]+)")
 ID_KEY = b"FtFyeHeWL36bANDy"
 CHAR_SUBST_OFFSETS = [-6, 3, 3, -5, 2, -6]
 
-def mediainfo_id(id):
-    id = quote(id)
-    id = ARC4.new(ID_KEY).encrypt(id.encode())
-    id = b64encode(id).decode()
-    id = id[::-1]
-    id = char_subst(id, CHAR_SUBST_OFFSETS)
-    id = b64encode(id.encode()).decode()
-    return id
+def mediainfo_id(vid_id):
+    result = quote(vid_id)
+    result = ARC4.new(ID_KEY).encrypt(result.encode())
+    result = b64encode(result).decode()
+    result = result[::-1]
+    result = char_subst(result, CHAR_SUBST_OFFSETS)
+    result = b64encode(result.encode()).decode()
+    return result
 
 def extract(session, url, **opts):
     match = EMBED_URL_REGEX.search(url)
     host = match.group(1)
-    id = match.group(2)
+    vid_id = match.group(2)
 
     vidstream_info = session.get(
-        f"{host}/mediainfo/{mediainfo_id(id)}",
+        f"{host}/mediainfo/{mediainfo_id(vid_id)}",
         headers={'referer': url}
     )
 

--- a/animdl/core/codebase/extractors/vidstream/__init__.py
+++ b/animdl/core/codebase/extractors/vidstream/__init__.py
@@ -1,94 +1,37 @@
 import functools
 import json
-from base64 import b64decode
+from base64 import b64encode
+from urllib.parse import quote
+from Cryptodome.Cipher import ARC4
 
 import regex
 
-from ...providers.nineanime import decipher
+from ...providers.nineanime.decipher import char_subst
 
-EMBED_URL_REGEX = regex.compile(r"(.+?/)(?:e(?:mbed)?)/([a-zA-Z0-9]+)")
+EMBED_URL_REGEX = regex.compile(r"(.+?)/(?:e(?:mbed)?)/([a-zA-Z0-9]+)")
+ID_KEY = b"FtFyeHeWL36bANDy"
+CHAR_SUBST_OFFSETS = [-6, 3, 3, -5, 2, -6]
 
-SIMPLE_OPERATE_REGEX = regex.compile(r"[0-9]+\s+.+?\s+[0-9]+")
-
-
-CIPHER_ALGORITHM_DATA_ENDPOINT = (
-    "https://raw.githubusercontent.com/AnimeJeff/Overflow/main/syek"
-)
-
-
-def isolated_eval(code, *, builtins=None):
-    try:
-        return eval(code, {"__builtins__": builtins or {}}, {})
-    except Exception:
-        return None
-
-
-@functools.lru_cache()
-def get_ciper_algorithm(session):
-    return json.loads(
-        b64decode(
-            b64decode(b64decode(session.get(CIPHER_ALGORITHM_DATA_ENDPOINT).content))
-        ).decode()
-    )
-
-
-def string_encrypt(text):
-    def repl(match):
-        value = ord(match.group(0)) + 13
-        return chr(
-            value if (90 if ord(match.group(0)) <= 90 else 122) >= value else value - 26
-        )
-
-    return regex.sub(r"[a-zA-Z]", repl, text)
-
-
-def conditional_encrypt(content, steps, b64_table):
-
-    for _ in steps:
-        if _ == "o":
-            content = decipher.encrypt(content, table=b64_table).replace("/", "_")
-
-        if _ == "s":
-            content = string_encrypt(content)
-
-        if _ == "a":
-            content = content[::-1]
-
-    return content
-
+def mediainfo_id(id):
+    id = quote(id)
+    id = ARC4.new(ID_KEY).encrypt(id.encode())
+    id = b64encode(id).decode()
+    id = id[::-1]
+    id = char_subst(id, CHAR_SUBST_OFFSETS)
+    id = b64encode(id.encode()).decode()
+    return id
 
 def extract(session, url, **opts):
-
     match = EMBED_URL_REGEX.search(url)
-    algorithm = get_ciper_algorithm(session)
+    host = match.group(1)
+    id = match.group(2)
 
-    b64_table = algorithm["encryptKey"]
-
-    content_id = decipher.encrypt(
-        decipher.cipher_keyed(algorithm["cipherKey"], match.group(2)),
-        table=b64_table,
+    vidstream_info = session.get(
+        f"{host}/mediainfo/{mediainfo_id(id)}",
+        headers={'referer': url}
     )
-
-    operations = algorithm["operations"]
-
-    dashes = conditional_encrypt(
-        "-".join(
-            str(
-                isolated_eval(
-                    str(ord(character)) + operations[str(count % len(operations))]
-                )
-            )
-            for count, character in enumerate(
-                conditional_encrypt(content_id, algorithm["pre"], b64_table)
-            )
-        ),
-        algorithm["post"],
-        b64_table,
-    )
-
-    vidstream_info = session.get(f"{match.group(1)}/{algorithm['mainKey']}/{dashes}")
 
     return [
         {"stream_url": content.get("file", ""), "headers": {"referer": url}}
-        for content in vidstream_info.json()["data"].get("media", {}).get("sources", [])
+        for content in vidstream_info.json()["result"].get("sources", [])
     ]

--- a/animdl/core/codebase/extractors/vidstream/__init__.py
+++ b/animdl/core/codebase/extractors/vidstream/__init__.py
@@ -1,34 +1,22 @@
-import functools
-import json
-from base64 import b64encode
-from urllib.parse import quote
-from Cryptodome.Cipher import ARC4
-
 import regex
 
-from ...providers.nineanime.decipher import char_subst
+from ...providers.nineanime.decipher import generate_vrf_from_content_id
 
 EMBED_URL_REGEX = regex.compile(r"(.+?)/(?:e(?:mbed)?)/([a-zA-Z0-9]+)")
 ID_KEY = b"FtFyeHeWL36bANDy"
 CHAR_SUBST_OFFSETS = [-6, 3, 3, -5, 2, -6]
 
-def mediainfo_id(vid_id):
-    result = quote(vid_id)
-    result = ARC4.new(ID_KEY).encrypt(result.encode())
-    result = b64encode(result).decode()
-    result = result[::-1]
-    result = char_subst(result, CHAR_SUBST_OFFSETS)
-    result = b64encode(result.encode()).decode()
-    return result
 
 def extract(session, url, **opts):
     match = EMBED_URL_REGEX.search(url)
     host = match.group(1)
-    vid_id = match.group(2)
+    video_id = match.group(2)
+
 
     vidstream_info = session.get(
-        f"{host}/mediainfo/{mediainfo_id(vid_id)}",
-        headers={'referer': url}
+        f"{host}/mediainfo/{generate_vrf_from_content_id(
+            video_id, offsets=CHAR_SUBST_OFFSETS, key=ID_KEY, reverse_later=False
+        )}", headers={"referer": url}
     )
 
     return [

--- a/animdl/core/codebase/providers/nineanime/decipher.py
+++ b/animdl/core/codebase/providers/nineanime/decipher.py
@@ -6,19 +6,19 @@ VRF_KEY = b"iECwVsmW38Qe94KN"
 URL_KEY = b"hlPeNwkncH0fq9so"
 CHAR_SUBST_OFFSETS = [-4, -4, 3, 3, 6, -4, 3, -6, -2, -4]
 
-def vrf_gen(id):
-    vrf = quote(id)
-    vrf = ARC4.new(VRF_KEY).encrypt(id.encode())
+def vrf_gen(vid_id):
+    vrf = quote(vid_id)
+    vrf = ARC4.new(VRF_KEY).encrypt(vid_id.encode())
     vrf = base64.b64encode(vrf).decode()
     vrf = char_subst(vrf, CHAR_SUBST_OFFSETS)
     vrf = vrf[::-1]
     vrf = base64.b64encode(vrf.encode()).decode()
     return vrf
 
-def char_subst(str, offsets):
+def char_subst(string, offsets):
     result = ""
-    for i in range(len(str)):
-        result += chr(ord(str[i]) + offsets[i % len(offsets)])
+    for i in range(len(string)):
+        result += chr(ord(string[i]) + offsets[i % len(offsets)])
     return result
 
 def decrypt_url(encrypted_url):

--- a/animdl/core/codebase/providers/nineanime/decipher.py
+++ b/animdl/core/codebase/providers/nineanime/decipher.py
@@ -1,28 +1,39 @@
 import base64
 from urllib.parse import quote, unquote
+
 from Cryptodome.Cipher import ARC4
 
 VRF_KEY = b"iECwVsmW38Qe94KN"
 URL_KEY = b"hlPeNwkncH0fq9so"
-CHAR_SUBST_OFFSETS = [-4, -4, 3, 3, 6, -4, 3, -6, -2, -4]
+CHAR_SUBST_OFFSETS = (-4, -4, 3, 3, 6, -4, 3, -6, -2, -4)
 
-def vrf_gen(vid_id):
-    vrf = quote(vid_id)
-    vrf = ARC4.new(VRF_KEY).encrypt(vid_id.encode())
-    vrf = base64.b64encode(vrf).decode()
-    vrf = char_subst(vrf, CHAR_SUBST_OFFSETS)
-    vrf = vrf[::-1]
-    vrf = base64.b64encode(vrf.encode()).decode()
-    return vrf
 
-def char_subst(string, offsets):
-    result = ""
-    for i in range(len(string)):
-        result += chr(ord(string[i]) + offsets[i % len(offsets)])
-    return result
+def char_subst(content: bytes, *, offsets=CHAR_SUBST_OFFSETS):
+    for n, value in enumerate(content):
+        yield (value + offsets[n % len(offsets)])
 
-def decrypt_url(encrypted_url):
-    url = base64.b64decode(encrypted_url)
-    url = ARC4.new(URL_KEY).decrypt(url)
-    url = unquote(url.decode())
-    return url
+
+def generate_vrf_from_content_id(
+    content_id: str,
+    key=VRF_KEY,
+    *,
+    offsets=CHAR_SUBST_OFFSETS,
+    encoding="utf-8",
+    reverse_later=True
+):
+    encoded_id = base64.b64encode(
+        ARC4.new(key).encrypt(quote(content_id).encode(encoding))
+    )
+
+    if reverse_later:
+        encoded_id = bytes(char_subst(encoded_id, offsets=offsets))[::-1]
+    else:
+        encoded_id = bytes(char_subst(encoded_id[::-1], offsets=offsets))
+
+    return base64.b64encode(encoded_id).decode(encoding)
+
+
+def decrypt_url(encrypted_url: str, key=URL_KEY, *, encoding="utf-8"):
+    return unquote(
+        ARC4.new(key).decrypt(base64.b64decode(encrypted_url)).decode(encoding)
+    )

--- a/animdl/core/codebase/providers/nineanime/decipher.py
+++ b/animdl/core/codebase/providers/nineanime/decipher.py
@@ -1,62 +1,28 @@
 import base64
-from textwrap import wrap
 from urllib.parse import quote, unquote
+from Cryptodome.Cipher import ARC4
 
-NORMAL_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+VRF_KEY = b"iECwVsmW38Qe94KN"
+URL_KEY = b"hlPeNwkncH0fq9so"
+CHAR_SUBST_OFFSETS = [-4, -4, 3, 3, 6, -4, 3, -6, -2, -4]
 
+def vrf_gen(id):
+    vrf = quote(id)
+    vrf = ARC4.new(VRF_KEY).encrypt(id.encode())
+    vrf = base64.b64encode(vrf).decode()
+    vrf = char_subst(vrf, CHAR_SUBST_OFFSETS)
+    vrf = vrf[::-1]
+    vrf = base64.b64encode(vrf.encode()).decode()
+    return vrf
 
-def cipher_keyed(key, plaintext):
-    cipher = ""
-    xcrypto = 0
+def char_subst(str, offsets):
+    result = ""
+    for i in range(len(str)):
+        result += chr(ord(str[i]) + offsets[i % len(offsets)])
+    return result
 
-    mapping = {_: _ for _ in range(256)}
-
-    for c in range(256):
-        xcrypto = (xcrypto + mapping[c] + ord(key[c % len(key)])) % 256
-        mapping[c], mapping[xcrypto] = mapping[xcrypto], mapping[c]
-
-    i = j = 0
-    for f in range(0, len(plaintext)):
-        j = (j + 1) % 256  # NOTE: Previously, this was 'j = (j + f) % 256'
-        i = (i + mapping[j]) % 256
-        mapping[i], mapping[j] = mapping[j], mapping[i]
-        cipher += chr(ord(plaintext[f]) ^ mapping[(mapping[i] + mapping[j]) % 256])
-
-    return cipher
-
-
-def get_salted_code(plaintext):
-    part_1 = encrypt((unquote(plaintext) + "000000")[:6])[0:4][::-1]
-    return part_1 + encrypt(cipher_keyed(part_1, unquote(plaintext)))[0:4].replace(
-        "=", ""
-    )
-
-
-def encrypt(data, *, table=NORMAL_TABLE):
-    return "".join(
-        table[int(segment.ljust(6, "0"), 2) if len(segment) < 6 else int(segment, 2)]
-        for segment in wrap(
-            "".join(bin(ord(c)).lstrip("0b").rjust(8, "0") for c in data), 6
-        )
-    )
-
-
-def decrypt_url(encrypted_url, secret):
-    return unquote(cipher_keyed(secret, decrypt(encrypted_url)))
-
-
-def encrypt_url(url, key):
-    return encrypt(cipher_keyed(key, quote(url)))
-
-
-def decrypt(data, *, table=NORMAL_TABLE):
-    return "".join(
-        map(
-            chr,
-            base64.b64decode(
-                (data + "=" * (len(data) % 4))
-                .translate(str.maketrans(table, NORMAL_TABLE))
-                .encode()
-            ),
-        )
-    )
+def decrypt_url(encrypted_url):
+    url = base64.b64decode(encrypted_url)
+    url = ARC4.new(URL_KEY).decrypt(url)
+    url = unquote(url.decode())
+    return url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "animdl"
-version = "1.7.18"
+version = "1.7.19"
 description = "A highly efficient, fast, powerful and light-weight anime downloader and streamer for your favorite anime."
 readme = "readme.txt"
 authors = [ "justfoolingaround <kr.justfoolingaround@gmail.com>",]


### PR DESCRIPTION
Fixes issues #238, #166

This PR adds the vrf parameter needed for 9anime requests, rewrites URL decryption using the RC4 cipher from pycryptodome and b64decode instead of reimplementing them, and updates Vidstream extraction

Currently Vidstream uses almost the same code as the vrf param, but with a different key and slightly different order