### PR TITLE
Update Gogoanime URL

### DIFF
--- a/animdl/core/config/__init__.py
+++ b/animdl/core/config/__init__.py
@@ -64,7 +64,7 @@ DEFAULT_CONFIG = {
         "animtime": "https://animtime.com/",
         "crunchyroll": "http://www.crunchyroll.com/",
         "kawaiifu": "https://kawaiifu.com/",
-        "gogoanime": "https://gogoanime.bid/",
+        "gogoanime": "https://anitaku.to/",
         "haho": "https://haho.moe/",
         "hentaistream": "https://hstream.moe/",
         "kamyroll_api": "https://kamyroll.herokuapp.com/",


### PR DESCRIPTION
Gogoanime has been migrated to a new domain:
https://anitaku.to/