### PR TITLE
Fixed kwik links for AnimePahe

### DIFF
--- a/animdl/core/codebase/providers/animepahe/inner/__init__.py
+++ b/animdl/core/codebase/providers/animepahe/inner/__init__.py
@@ -4,7 +4,7 @@ KWIK_PARAMS_RE = regex.compile(r'\("(\w+)",\d+,"(\w+)",(\d+),(\d+),\d+\)')
 KWIK_D_URL = regex.compile(r'action="(.+?)"')
 KWIK_D_TOKEN = regex.compile(r'value="(.+?)"')
 
-KWIK_REDIRECTION_RE = regex.compile(r'<a href="(.+?)" .+?>Redirect me</a>')
+KWIK_REDIRECTION_RE = regex.compile(r'https://kwik\.cx.+?"')
 
 CHARACTER_MAP = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ+/"
 
@@ -47,8 +47,8 @@ def get_animepahe_url(session, pahe_win_url):
 
     response = session.get(pahe_win_url)
     response.raise_for_status()
-
-    url = KWIK_REDIRECTION_RE.search(response.text).group(1)
+    
+    url = KWIK_REDIRECTION_RE.search(response.text).group()[:-1]
 
     download_page = session.get(url)
 


### PR DESCRIPTION
It turned out that the redirect page just changed the location where the link is placed; instead of it being in the "<a href..." block, it is now in a javascript block.  The only change that had to be made was the regex matching.  The change should work, but as always, test it before merging.

I figured that pulling the link out of the scripts section by matching a regex of `https://kwik.cx/` would be a more elegant and less cluttered way than waiting five seconds for the link to be placed in the spot checked before, and possibly more future-proof as well.