### PR TITLE
Fix: Mpv audio tracks and subtitles

### DIFF
--- a/animdl/core/cli/helpers/players/mpv.py
+++ b/animdl/core/cli/helpers/players/mpv.py
@@ -36,7 +36,7 @@ class MPVDefaultPlayer(BasePlayer):
     ):
         args = (self.executable, *self.args, stream_url)
 
-        if audio_tracks is not None:
+        if audio_tracks:
             audio_tracks = map(
                 lambda audio_track: audio_track.replace(self.path_joiner, f"\{self.path_joiner}"),
                 audio_tracks
@@ -60,7 +60,7 @@ class MPVDefaultPlayer(BasePlayer):
                 f"{self.opts_spec['media-title']}={title}",
             )
 
-        if subtitles is not None:
+        if subtitles:
             subtitles = map(
                 lambda subtitle: subtitle.replace(self.path_joiner, f"\{self.path_joiner}"),
                 subtitles

--- a/animdl/core/cli/helpers/players/mpv.py
+++ b/animdl/core/cli/helpers/players/mpv.py
@@ -37,6 +37,11 @@ class MPVDefaultPlayer(BasePlayer):
         args = (self.executable, *self.args, stream_url)
 
         if audio_tracks is not None:
+            audio_tracks = map(
+                lambda audio_track: audio_track.replace(self.path_joiner, f"\{self.path_joiner}"),
+                audio_tracks
+            )
+
             args += (
                 f"{self.opts_spec['audios']}={self.path_joiner.join(audio_tracks)}",
             )
@@ -56,6 +61,11 @@ class MPVDefaultPlayer(BasePlayer):
             )
 
         if subtitles is not None:
+            subtitles = map(
+                lambda subtitle: subtitle.replace(self.path_joiner, f"\{self.path_joiner}"),
+                subtitles
+            )
+
             args += (
                 f"{self.opts_spec['subtitles']}={self.path_joiner.join(subtitles)}",
             )


### PR DESCRIPTION
Fixes #302 

And tries to fix this thing #255  (they were trying to fix webVTT subtitles apparently? But this bug also affects ASS files and audio tracks it seems...)