### PR TITLE
Update readme.md to contain new windows configuration file location

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -214,7 +214,7 @@ Else, a file with the name `animdl_config.yml` in the working directory will be 
 Futhermore, the configuration files can be globally placed at:
 
 *   Windows:
-    *   `%USERPROFILE%/.animdl/config.yml`
+    *   `%LOCALAPPDATA%/.config/animdl/config.yml`
 *   Anything else:
     *   `$HOME/.config/animdl/config.yml`
 


### PR DESCRIPTION
Configuration file location is deprecated and has been moved to a new location in windows, this change should be reflected in the readme